### PR TITLE
Add repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   ],
   "license": "MIT",
   "author": "Matthew Beale <matt.beale@madhatted.com>",
+  "repository": "https://github.com/201-created/ember-inline-css",
   "scripts": {},
   "dependencies": {
     "broccoli-merge-trees": "^2.0.0",


### PR DESCRIPTION
This will allow Ember Observer and npm to link to the repo