### PR TITLE
Ensure other attributes are ignored

### DIFF
--- a/lib/css_injector.js
+++ b/lib/css_injector.js
@@ -17,7 +17,7 @@ CSSInjector.prototype = {
     this.filePathsToInject.forEach((p) => {
       if (inputHTML.indexOf(p) === -1) { return; }
 
-      let regex = new RegExp(`<link rel="stylesheet" href="[^"]*${p}"[^>]*>`)
+      let regex = new RegExp(`<link[^>]* href="[^"]*${p}"[^>]*>`)
 
       inputHTML = inputHTML.replace(regex, () => {
         return this.wrapCSS(fs.readFileSync(path.join(this.rootPath, p), 'utf-8'));

--- a/tests/lib/css_injector-test.js
+++ b/tests/lib/css_injector-test.js
@@ -44,4 +44,27 @@ QUnit.module('CSSInjector', function(hooks) {
 
     assert.equal(output.read()['index.html'], `<style>a { background-color: blue; }</style>\n<link rel=\"stylesheet\" href=\"/assets/app.css\">`);
   });
+
+  test('matches link tags with any attributes', function(assert) {
+    let fixture = {
+      'assets': {
+        'vendor.css': 'a { background-color: blue; }',
+        'app.css': 'h1 { background-color: green; }'
+      },
+      'index.html': stripIndent`
+        <link type="text/css" rel="stylesheet" href="/assets/vendor.css">
+        <link integrity="" rel="stylesheet" href="/assets/app.css">
+      `
+    };
+    input.write(fixture);
+
+    let injector = new CSSInjector({
+      rootPath: input.path(),
+      filePathsToInject: [ 'assets/vendor.css', 'assets/app.css' ]
+    });
+
+    injector.write(path.join(output.path(), 'index.html'))
+
+    assert.equal(output.read()['index.html'], `<style>a { background-color: blue; }</style>\n<style>h1 { background-color: green; }</style>`);
+  });
 });


### PR DESCRIPTION
If an application includes a link tag with attributes other than
`rel="stylesheet"` and `href="something"` the regex to find the link
fails.  This allows any attribute combo to come before href and still
match.

This was particularly problematic when dealing with links that include
`type="text/css"` for example.