### PR TITLE
Adds support to match and replace fingerprinted assets

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ module.exports = {
           ];
         } else {
           filePathsToInject = [
-            this.app.options.outputPaths.app.css.vendor,
+            this.app.options.outputPaths.vendor.css,
             this.app.options.outputPaths.app.css.app
           ];
         }

--- a/lib/css_injector.js
+++ b/lib/css_injector.js
@@ -20,7 +20,7 @@ CSSInjector.prototype = {
       let assetPath = filePath.substr(0, pathIndex);
       let fileName = filePath.substr(pathIndex + 1) || '';
       fileName = fileName.replace('.css', '');
-      let rootPath = `${this.rootPath}${assetPath}`;
+      let rootPath = path.join(this.rootPath, assetPath);
 
       /* RegExp to match both fingerprinted and non fingerprinted file names */
       let nameRegex = new RegExp(`(${fileName}.css|${fileName}-\\b[0-9a-f]{5,40}\\b.css)`);

--- a/lib/css_injector.js
+++ b/lib/css_injector.js
@@ -16,48 +16,47 @@ CSSInjector.prototype = {
 
     let generatedCss = [];
     this.filePathsToInject.forEach((filePath) => {
-      if (filePath) {
-        let pathIndex = filePath.lastIndexOf('/');
-        let assetPath = filePath.substr(0, pathIndex);
-        let fileName = filePath.substr(pathIndex + 1) || '';
-        fileName = fileName.replace('.css', '');
-        let rootPath = `${this.rootPath}${assetPath}`;
+      let pathIndex = filePath.lastIndexOf('/');
+      let assetPath = filePath.substr(0, pathIndex);
+      let fileName = filePath.substr(pathIndex + 1) || '';
+      fileName = fileName.replace('.css', '');
+      let rootPath = `${this.rootPath}${assetPath}`;
 
-        /* RegExp to match both fingerprinted and non fingerprinted file names */
-        let nameRegex = new RegExp(`(${fileName}.css|${fileName}-\\b[0-9a-f]{5,40}\\b.css)`);
-        let matchedFile = '';
+      /* RegExp to match both fingerprinted and non fingerprinted file names */
+      let nameRegex = new RegExp(`(${fileName}.css|${fileName}-\\b[0-9a-f]{5,40}\\b.css)`);
+      let matchedFile = '';
 
-        /* Generates a array css files from the output directory.
-         * Directory operation is done only once.
-         * Later this `generatedCss` array is iterated to match the fileName.
-         */
-        if (generatedCss.length === 0) {
-          fs.readdirSync(rootPath).forEach(file => {
-            if (file.indexOf('.css') > 0) {
-              generatedCss.push(`${file}`);
-              if(nameRegex.test(file)) {
-                matchedFile = file;
-              }
-            }
-          });
-        }
-
-        /* Iterates the `generatedCss` array to get the matchedFile, when it is empty. */
-        if (matchedFile.length === 0) {
-          generatedCss.forEach(file => {
+      /* Generates a array css files from the output directory.
+       * Directory operation is done only once.
+       * Later this `generatedCss` array is iterated to match the fileName.
+       */
+      if (generatedCss.length === 0) {
+        fs.readdirSync(rootPath).forEach(file => {
+          if (file.indexOf('.css') > 0) {
+            generatedCss.push(`${file}`);
             if(nameRegex.test(file)) {
               matchedFile = file;
-              return;
             }
-          })
-        }
-
-        if (inputHTML.indexOf(matchedFile) === -1) { return; }
-        let regex = new RegExp(`<link[^>]* href="[^"]*${assetPath}/${matchedFile}"[^>]*>`)
-        inputHTML = inputHTML.replace(regex, () => {
-          return this.wrapCSS(fs.readFileSync(path.join(rootPath, matchedFile), 'utf-8'));
+          }
         });
       }
+
+      /* Iterates the `generatedCss` array to get the matchedFile, when it is empty. */
+      if (matchedFile.length === 0) {
+        generatedCss.forEach(file => {
+          if(nameRegex.test(file)) {
+            matchedFile = file;
+            return;
+          }
+        })
+      }
+
+      if (inputHTML.indexOf(`${assetPath}/${matchedFile}`) === -1) { return; }
+
+      let regex = new RegExp(`<link[^>]* href="[^"]*${assetPath}/${matchedFile}"[^>]*>`)
+      inputHTML = inputHTML.replace(regex, () => {
+        return this.wrapCSS(fs.readFileSync(path.join(rootPath, matchedFile), 'utf-8'));
+      });
     });
 
     fs.writeFileSync(outputPath, inputHTML, 'utf-8');

--- a/lib/css_injector.js
+++ b/lib/css_injector.js
@@ -14,14 +14,50 @@ CSSInjector.prototype = {
   write: function(outputPath) {
     let inputHTML = fs.readFileSync(path.join(this.rootPath, 'index.html'), 'utf-8');
 
-    this.filePathsToInject.forEach((p) => {
-      if (inputHTML.indexOf(p) === -1) { return; }
+    let generatedCss = [];
+    this.filePathsToInject.forEach((filePath) => {
+      if (filePath) {
+        let pathIndex = filePath.lastIndexOf('/');
+        let assetPath = filePath.substr(0, pathIndex);
+        let fileName = filePath.substr(pathIndex + 1) || '';
+        fileName = fileName.replace('.css', '');
+        let rootPath = `${this.rootPath}${assetPath}`;
 
-      let regex = new RegExp(`<link[^>]* href="[^"]*${p}"[^>]*>`)
+        /* RegExp to match both fingerprinted and non fingerprinted file names */
+        let nameRegex = new RegExp(`(${fileName}.css|${fileName}-\\b[0-9a-f]{5,40}\\b.css)`);
+        let matchedFile = '';
 
-      inputHTML = inputHTML.replace(regex, () => {
-        return this.wrapCSS(fs.readFileSync(path.join(this.rootPath, p), 'utf-8'));
-      });
+        /* Generates a array css files from the output directory.
+         * Directory operation is done only once.
+         * Later this `generatedCss` array is iterated to match the fileName.
+         */
+        if (generatedCss.length === 0) {
+          fs.readdirSync(rootPath).forEach(file => {
+            if (file.indexOf('.css') > 0) {
+              generatedCss.push(`${file}`);
+              if(nameRegex.test(file)) {
+                matchedFile = file;
+              }
+            }
+          });
+        }
+
+        /* Iterates the `generatedCss` array to get the matchedFile, when it is empty. */
+        if (matchedFile.length === 0) {
+          generatedCss.forEach(file => {
+            if(nameRegex.test(file)) {
+              matchedFile = file;
+              return;
+            }
+          })
+        }
+
+        if (inputHTML.indexOf(matchedFile) === -1) { return; }
+        let regex = new RegExp(`<link[^>]* href="[^"]*${assetPath}/${matchedFile}"[^>]*>`)
+        inputHTML = inputHTML.replace(regex, () => {
+          return this.wrapCSS(fs.readFileSync(path.join(rootPath, matchedFile), 'utf-8'));
+        });
+      }
     });
 
     fs.writeFileSync(outputPath, inputHTML, 'utf-8');

--- a/tests/lib/css_injector-test.js
+++ b/tests/lib/css_injector-test.js
@@ -67,4 +67,27 @@ QUnit.module('CSSInjector', function(hooks) {
 
     assert.equal(output.read()['index.html'], `<style>a { background-color: blue; }</style>\n<style>h1 { background-color: green; }</style>`);
   });
+
+  test('correctly matches and replaces the fingerprinted assets', function(assert) {
+    let fixture = {
+      'assets': {
+        'vendor.css': 'a { background-color: blue; }',
+        'app.css': 'h1 { background-color: green; }'
+      },
+      'index.html': stripIndent`
+        <link type="text/css" rel="stylesheet" href="/assets/vendor-225c0cfbe857d81d657f77007d4c62a7.css">
+        <link integrity="" rel="stylesheet" href="/assets/app.css">
+      `
+    };
+    input.write(fixture);
+
+    let injector = new CSSInjector({
+      rootPath: input.path(),
+      filePathsToInject: [ 'assets/vendor.css', 'assets/app.css' ]
+    });
+
+    injector.write(path.join(output.path(), 'index.html'))
+
+    assert.equal(output.read()['index.html'], `<style>a { background-color: blue; }</style>\n<style>h1 { background-color: green; }</style>`);
+  });
 });

--- a/tests/lib/css_injector-test.js
+++ b/tests/lib/css_injector-test.js
@@ -71,7 +71,7 @@ QUnit.module('CSSInjector', function(hooks) {
   test('correctly matches and replaces the fingerprinted assets', function(assert) {
     let fixture = {
       'assets': {
-        'vendor.css': 'a { background-color: blue; }',
+        'vendor-225c0cfbe857d81d657f77007d4c62a7.css': 'a { background-color: blue; }',
         'app.css': 'h1 { background-color: green; }'
       },
       'index.html': stripIndent`


### PR DESCRIPTION
- Updates the regex to match both fingerprinted and non fingerprinted file names.
- Used `readdirSync` to read the list of css files under the output directory, then matches the fingerprinted file from this list.