### PR TITLE
Configure to run before broccoli-asset-rev

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
     "co": "^4.6.0",
     "common-tags": "^1.4.0",
     "qunitjs": "^2.4.0"
+  },
+  "ember-addon": {
+    "before": "broccoli-asset-rev"
   }
 }


### PR DESCRIPTION
This addon needs to run before broccoli-asset-rev applies the fingerprinted suffix to the built CSS files. This sidesteps the issue of needing to locate the CSS files after fingerprinting.

Resolves #9 
Closes #10 